### PR TITLE
Fix initial waypoint not removing properly

### DIFF
--- a/src/pathGenerator/Gui.java
+++ b/src/pathGenerator/Gui.java
@@ -220,6 +220,7 @@ public class Gui {
 				if(points.size()== 1)
 				{
 					txtAreaWaypoints.setText(null);
+					points.remove(0);
 				}
 				else{
 					int pos = txtAreaWaypoints.getText().lastIndexOf("\n", txtAreaWaypoints.getText().length() -2 );


### PR DESCRIPTION
Clicking "Delete last point" will not delete the first waypoint, resulting in bad trajectories being generated should the starting position change.